### PR TITLE
Improve Integration as a Dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info/
 __pycache__
+*.coverage*
 
 outputs
 results

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ PaperContext.parse_raw("""{
     "title": "<title>",
     "abstract": "<abstract>",
     "full_text": [{
-        "name" : "<section_title>",
+        "section_name" : "<section_title>",
         "paragraphs": ["<paragraph>", ...]
     }, ...]
 }""")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "decontext"
-version = "0.1.2"
+version = "0.1.3"
 description = """\
 Pipeline for decontextualization of scientific snippets.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "filelock==3.12.2",
     "Jinja2==3.1.2",
     "shadow-scholar==0.6.1",
-    "omegaconf==2.2.3",
+    "omegaconf>=2.3.0",
     "openai==0.27.7",
     "pydantic==1.9.1",
     "tiktoken==0.4.0",
@@ -85,7 +85,6 @@ dev = [
     "black[jupyter]>=21.12b0",
     "isort>=5.8.0",
     "mypy>=0.971",
-    "pytest>=5.2",
     "ipython>=8.4.0",
     "autopep8>=1.7.0",
     "flake8>=5.0",
@@ -93,6 +92,8 @@ dev = [
     "flake8-pyi>=22.8.1",
     "Flake8-pyproject>=1.1.0",
     "pytest==7.1.3",
+    "pytest-xdist",
+    "pytest-cov",
 ]
 
 [tool.black]
@@ -143,9 +144,20 @@ per-file-ignores = [
 ]
 
 [tool.pytest.ini_options]
+addopts = '-n auto --cov=.'
 testpaths = ["tests/"]
 python_classes = ["Test*", "*Test"]
 log_format = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
 log_level = "DEBUG"
 markers = []
 filterwarnings = []
+
+[tool.coverage.run]
+omit = [
+    '*__init__*',
+    '*Test*',
+    'tests/fixtures/*',
+    'tests/*',
+]
+[tool.coverage.report]
+fail_under = 25

--- a/src/decontext/data_types.py
+++ b/src/decontext/data_types.py
@@ -144,7 +144,7 @@ class PaperSnippet(BaseModel):
                 if qae.evidence is None:
                     qae.evidence = []
                 for section, additional_paragraph in zip(
-                    additional_paragraphs, sections
+                    sections, additional_paragraphs
                 ):
                     qae.evidence.append(
                         EvidenceParagraph(

--- a/src/decontext/model.py
+++ b/src/decontext/model.py
@@ -14,6 +14,7 @@ from decontext.data_types import (
     AnthropicResponse,
     ModelResponse,
 )
+from decontext.logging import warn
 
 OPENAI_CHAT_MODEL_NAMES = {
     "gpt-3.5-turbo",
@@ -48,7 +49,11 @@ class GPT3Model:
         """
         self._name = model_name
         self.cache = DiskCache.load()
-        openai.api_key = os.environ["OPENAI_API_KEY"]
+        if "OPENAI_API_KEY" not in os.environ:
+            warn("OPENAI_API_KEY not found in environment variables.\
+                Set OPEN_API_KEY with your API key to use the OpenAI API.")
+        else:
+            openai.api_key = os.environ["OPENAI_API_KEY"]
 
         self.params = {
             "model": self.name,

--- a/src/decontext/model.py
+++ b/src/decontext/model.py
@@ -50,8 +50,8 @@ class GPT3Model:
         self._name = model_name
         self.cache = DiskCache.load()
         if "OPENAI_API_KEY" not in os.environ:
-            warn("OPENAI_API_KEY not found in environment variables.\
-                Set OPEN_API_KEY with your API key to use the OpenAI API.")
+            warn("OPENAI_API_KEY not found in environment variables."
+                "Set OPEN_API_KEY with your API key to use the OpenAI API.")
         else:
             openai.api_key = os.environ["OPENAI_API_KEY"]
 

--- a/src/decontext/pipeline.py
+++ b/src/decontext/pipeline.py
@@ -2,7 +2,6 @@ from typing import List, Optional, Tuple, Union
 
 from pydantic import BaseModel
 
-
 from decontext.data_types import (
     PaperContext,
     PaperSnippet,
@@ -20,21 +19,25 @@ class Pipeline(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
-
+# We don't want to instantiatate the pipelines here
 class RetrievalQAPipeline(Pipeline):
-    steps: List[PipelineStep] = [
-        TemplateQGenStep(),
-        TemplateRetrievalQAStep(),
-        TemplateSynthStep(),
-    ]
+
+    def __init__(self, **data):
+        data["steps"] = [
+            TemplateQGenStep(),
+            TemplateRetrievalQAStep(),
+            TemplateSynthStep(),
+        ]
 
 
 class FullTextQAPipeline(Pipeline):
-    steps: List[PipelineStep] = [
-        TemplateQGenStep(),
-        TemplateFullTextQAStep(),
-        TemplateSynthStep(),
-    ]
+
+    def __init__(self, **data):
+        data["steps"] = [
+            TemplateQGenStep(),
+            TemplateFullTextQAStep(),
+            TemplateSynthStep(),
+        ]
 
 
 def decontext(

--- a/src/decontext/step/qa.py
+++ b/src/decontext/step/qa.py
@@ -128,7 +128,7 @@ class TemplateRetrievalQAStep(QAStep, TemplatePipelineStep):
                     "abstract": snippet.context.abstract,
                     "section_with_snippet": section_with_snippet,
                     "paragraph_with_snippet": paragraph_with_snippet,
-                    "unique_evidence": list(unique_evidence),
+                    "unique_evidence": unique_evidence,
                 }
             )
             result = self.model(prompt)

--- a/src/decontext/step/qa.py
+++ b/src/decontext/step/qa.py
@@ -9,7 +9,7 @@ from shadow_scholar.app import pdod
 
 from decontext.data_types import PaperSnippet, Section
 from decontext.step.step import QAStep, TemplatePipelineStep
-from decontext.utils import none_check
+from decontext.utils import none_check, unique
 
 
 class TemplateRetrievalQAStep(QAStep, TemplatePipelineStep):
@@ -104,16 +104,16 @@ class TemplateRetrievalQAStep(QAStep, TemplatePipelineStep):
     def run(self, snippet: PaperSnippet):
         self.retrieve(snippet)
         for question in snippet.qae:
-            unique_evidence = set(
-                [
-                    ev.paragraph
-                    for ev in (none_check(question.evidence, []))
-                    if (
-                        ev.paragraph != snippet.context.abstract
-                        and ev.paragraph != snippet.paragraph_with_snippet
-                    )
-                ]
-            )
+            evidence = [
+                ev.paragraph
+                for ev in (none_check(question.evidence, []))
+                if (
+                    ev.paragraph != snippet.context.abstract
+                    and ev.paragraph != snippet.paragraph_with_snippet
+                )
+            ]
+            # https://stackoverflow.com/questions/9792664/converting-a-list-to-a-set-changes-element-order
+            unique_evidence = unique(evidence)
 
             paragraph_with_snippet = snippet.paragraph_with_snippet.paragraph
             section_with_snippet = none_check(

--- a/src/decontext/utils.py
+++ b/src/decontext/utils.py
@@ -1,6 +1,6 @@
 import base64
 import hashlib
-from typing import TypeVar, Optional
+from typing import TypeVar, Optional, List, Any
 
 
 def hash_strs(*strs, lim=10) -> str:
@@ -34,3 +34,13 @@ def none_check(value: Optional[T], default: T) -> T:
         Any: returns the value or a new instance of the type of the value if the value is None
     """
     return value if value is not None else default
+
+
+def unique(list_: List[Any]):
+    seen = set()
+    result = []
+    for elem in list_:
+        if elem not in seen:
+            seen.add(elem)
+            result.append(elem)
+    return result

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,21 @@
+import io
+import os
+import sys
+from unittest import mock
+
+from decontext.model import load_model
+
+# temporarily clear the environment variables
+@mock.patch.dict(os.environ, {}, clear=True)
+def test_warning_no_api_key():
+    # temporarily redirect stdout
+    captured_output = io.StringIO()
+    sys.stdout = captured_output
+
+    # loading the model should trigger the warning
+    model = load_model("text-davinci-003")
+
+    # reset stdout
+    sys.stdout = sys.__stdout__
+    assert (captured_output.getvalue() == "[WARNING] OPENAI_API_KEY not found in environment variables."
+                "Set OPEN_API_KEY with your API key to use the OpenAI API.\n")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 from typing import Optional, get_type_hints
 
-from decontext.utils import none_check
+from decontext.utils import none_check, unique
 
 
 def test_none_check() -> None:
@@ -13,3 +13,9 @@ def test_none_check() -> None:
 
     x = None
     assert none_check(x, "") == ""
+
+def test_unique() -> None:
+    x = [1, 2, 3, 4, 5, 5, 5, 5, 5]
+    assert unique(x) == [1, 2, 3, 4, 5]
+    
+    assert unique([]) == []


### PR DESCRIPTION
This PR fixes some bugs decreases some friction from using `decontext` as a dependency. Bugs that are fixed:
- Sections and paragraphs were swapped leading to nonsense generations.
- A `set` was used to make the items in a list unique, which ended up scrambling them. Caching relied on that order.

Friction addressed:
- Some dependencies were unpinned (though there still has to be a bit more of this).
- It's no longer necessary to have an OpenAI API key in an environment variable to import the module.